### PR TITLE
add synchronized to protect the map, to fix the bug:

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ dist/
 scratch/
 .cachedir/
 memcached-release*
+/bin

--- a/src/com/meetup/memcached/SockIOPool.java
+++ b/src/com/meetup/memcached/SockIOPool.java
@@ -1066,7 +1066,7 @@ public class SockIOPool {
 	 * @param host host this socket is connected to
 	 * @param socket socket to add
 	 */
-	protected void addSocketToPool( Map<String,Map<SockIO,Long>> pool, String host, SockIO socket ) {
+	synchronized protected void addSocketToPool( Map<String,Map<SockIO,Long>> pool, String host, SockIO socket ) {
 
 		if ( pool.containsKey( host ) ) {
 			Map<SockIO,Long> sockets = pool.get( host );
@@ -1111,7 +1111,7 @@ public class SockIOPool {
 	 * @param pool pool to clear
 	 * @param host host to clear
 	 */
-	protected void clearHostFromPool( Map<String,Map<SockIO,Long>> pool, String host ) {
+	synchronized protected void clearHostFromPool( Map<String,Map<SockIO,Long>> pool, String host ) {
 
 		if ( pool.containsKey( host ) ) {
 			Map<SockIO,Long> sockets = pool.get( host );


### PR DESCRIPTION
java.util.ConcurrentModificationException
         at java.util.IdentityHashMap.remove(IdentityHashMap.java:729)
         at com.ycache.danga.MemCached.SockIOPool.clearHostFromPool(Unknown Source)
         at com.ycache.danga.MemCached.SockIOPool.createSocket(Unknown Source)
         at com.ycache.danga.MemCached.SockIOPool.getConnection(Unknown Source)
         at com.ycache.danga.MemCached.SockIOPool.getSock(Unknown Source)
         at com.ycache.danga.MemCached.MemCachedClient.get(Unknown Source)
         at com.ycache.danga.MemCached.MemCachedClient.get(Unknown Source)
         at com.yihaodian.common.ycache.memcache.impl.BaseMemcacheProxy.get(Unknown Source)
